### PR TITLE
Fix small typo in snapshot removal policy

### DIFF
--- a/resources/truenas-restic/restic-driver
+++ b/resources/truenas-restic/restic-driver
@@ -76,7 +76,7 @@ restic forget --verbose \
   --tag periodic \
   --group-by "paths,tags" \
   --keep-last $MINIMUM_SNAPSHOTS_RETAINED \
-  --keep-hours $HOURS_RETAINED \
+  --keep-hourly $HOURS_RETAINED \
   --keep-daily $DAYS_RETAINED \
   --keep-weekly $WEEKS_RETAINED \
   --keep-monthly $MONTHS_RETAINED \


### PR DESCRIPTION
The `--keep-hours` typo should be written as `--keep-hourly`. Restic does not recognize `--keep-hours`.

https://restic.readthedocs.io/en/latest/060_forget.html